### PR TITLE
Registration email

### DIFF
--- a/VotingApplication/Controllers/AuthenticationController.cs
+++ b/VotingApplication/Controllers/AuthenticationController.cs
@@ -57,10 +57,25 @@ namespace VotingApplication.Controllers
                 }
                 else
                 {
-                    ModelState.AddModelError(string.Empty, "Invalid username or password.");
+                    if (result.IsLockedOut)
+                    {
+                        ModelState.AddModelError(string.Empty, "Account is locked out.");
+                    }
+                    else if (result.IsNotAllowed)
+                    {
+                        ModelState.AddModelError(string.Empty, "Email confirmation required.");
+                    }
+                    else if (result.RequiresTwoFactor)
+                    {
+                        ModelState.AddModelError(string.Empty, "Two factor authentication required.");
+                    }
+                    else
+                    {
+                        ModelState.AddModelError(string.Empty, "Invalid username or password.");
+                    }
                 }
             }
-
+            
             return View("Login", model);
         }
 

--- a/VotingApplication/Controllers/RegistrationController.cs
+++ b/VotingApplication/Controllers/RegistrationController.cs
@@ -55,7 +55,9 @@ namespace VotingApplication.Controllers
                 {
                     await SendConfirmationEmailAsync(user);
 
-                    return View("EmailConfirmationSent");
+                    var modelEmail = new ConfirmEmailViewModel();
+                    modelEmail.State = ConfirmEmailViewModel.Status.Sent;
+                    return View("EmailConfirmationSent", modelEmail);
                 }
             }
 
@@ -129,8 +131,7 @@ namespace VotingApplication.Controllers
             return Json(true);
         }
         #endregion
-
-        //[AcceptVerbs("Get", "Post")]
+        
         [HttpGet]
         [AllowAnonymous]
         public async Task<IActionResult> EmailConfirmedAsync(string username, string token)
@@ -145,21 +146,21 @@ namespace VotingApplication.Controllers
                     {
                         return View("EmailConfirmed");
                     }
-                    else
-                    {
-                        foreach (IdentityError error in confirm.Errors)
-                        {
-                            ModelState.AddModelError(string.Empty, error.Description);
-                        }
-                    }
-                }
-                else
-                {
-                    ModelState.AddModelError(string.Empty, "Invalid user.");
                 }
             }
-            
-            return View("EmailConfirmationSent", new ConfirmEmailViewModel());
+
+            var model = new ConfirmEmailViewModel();
+            model.State = ConfirmEmailViewModel.Status.Error;
+            return View("EmailConfirmationSent", model);
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult RequestEmailConfirmation()
+        {
+            var model = new ConfirmEmailViewModel();
+            model.State = ConfirmEmailViewModel.Status.Request;
+            return View("EmailConfirmationSent", model);
         }
 
         [HttpPost]
@@ -171,10 +172,12 @@ namespace VotingApplication.Controllers
                 var user = await _UserManager.FindByEmailAsync(model.Email);
 
                 await SendConfirmationEmailAsync(user);
-                
-                return View("EmailConfirmationSent");
+
+                model.Email = "";
+                model.State = ConfirmEmailViewModel.Status.Sent;
+                return View("EmailConfirmationSent", model);
             }
-            
+
             return View("EmailConfirmationSent", model);
         }
         

--- a/VotingApplication/Controllers/RegistrationController.cs
+++ b/VotingApplication/Controllers/RegistrationController.cs
@@ -24,9 +24,8 @@ namespace VotingApplication.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        public IActionResult Register(string returnUrl = null)
+        public IActionResult Register()
         {
-            ViewData["ReturnUrl"] = returnUrl;
             ViewData["Purpose"] = "Create Account";
             ViewData["Submit"] = "Create";
 
@@ -37,9 +36,8 @@ namespace VotingApplication.Controllers
         // this is not implemented yet
         //[RequireHttps]
         [AllowAnonymous]
-        public async Task<IActionResult> RegisterAsync(RegistrationViewModel model, string returnUrl = null)
+        public async Task<IActionResult> RegisterAsync(RegistrationViewModel model)
         {
-            ViewData["ReturnUrl"] = returnUrl;
             ViewData["Purpose"] = "Create Account";
             ViewData["Submit"] = "Create";
 
@@ -55,47 +53,16 @@ namespace VotingApplication.Controllers
 
                 if (result.Succeeded)
                 {
-                    var fromAddress = new MailAddress("votingnotification6@gmail.com", "Voting System");
-                    var toAddress = new MailAddress(model.Email, model.Username);
-                    const string fromPassword = "Team6Admin";
-                    const string subject = "Welcome Confirmation Email";
-                    string body = "Hello " + model.Username;
+                    await SendConfirmationEmailAsync(user);
 
-                    var smtp = new SmtpClient
-                    {
-                        Host = "smtp.gmail.com",
-                        Port = 587,
-                        EnableSsl = true,
-                        DeliveryMethod = SmtpDeliveryMethod.Network,
-                        UseDefaultCredentials = false,
-                        Credentials = new NetworkCredential(fromAddress.Address, fromPassword)
-                    };
-                    using (var message = new MailMessage(fromAddress, toAddress)
-                    {
-                        Subject = subject,
-                        Body = body
-                    })
-                    {
-                        smtp.Send(message);
-                    }
-
-                    await _SignInManager.SignInAsync(user, isPersistent: false);
-
-                    if (string.IsNullOrEmpty(returnUrl))
-                    {
-                        string action = nameof(UserController.Dashboard);
-                        string controller = nameof(UserController);
-                        controller = controller.Remove(controller.Length - 10);
-                        return RedirectToAction(action, controller);
-                    }
-
-                    return Redirect(returnUrl);
+                    return View("EmailConfirmationSent");
                 }
             }
 
             return View("Register", model);
         }
 
+        #region Verify Registration View Model
         [HttpGet]
         // this is not implemented yet
         //[RequireHttps]
@@ -161,5 +128,120 @@ namespace VotingApplication.Controllers
 
             return Json(true);
         }
+        #endregion
+
+        //[AcceptVerbs("Get", "Post")]
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> EmailConfirmedAsync(string username, string token)
+        {
+            if (username != null && token != null)
+            {
+                var user = await _UserManager.FindByNameAsync(username);
+                if (user != null)
+                {
+                    var confirm = await _UserManager.ConfirmEmailAsync(user, token);
+                    if (confirm.Succeeded)
+                    {
+                        return View("EmailConfirmed");
+                    }
+                    else
+                    {
+                        foreach (IdentityError error in confirm.Errors)
+                        {
+                            ModelState.AddModelError(string.Empty, error.Description);
+                        }
+                    }
+                }
+                else
+                {
+                    ModelState.AddModelError(string.Empty, "Invalid user.");
+                }
+            }
+            
+            return View("EmailConfirmationSent", new ConfirmEmailViewModel());
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> EmailConfirmationSentAsync(ConfirmEmailViewModel model)
+        {
+            if (ModelState.IsValid)
+            {
+                var user = await _UserManager.FindByEmailAsync(model.Email);
+
+                await SendConfirmationEmailAsync(user);
+                
+                return View("EmailConfirmationSent");
+            }
+            
+            return View("EmailConfirmationSent", model);
+        }
+        
+        private async Task SendConfirmationEmailAsync(ApplicationUser user)
+        {
+            if (_UserManager != null && user != null)
+            {
+                string confirmationToken = await _UserManager.GenerateEmailConfirmationTokenAsync(user);
+                const string action = nameof(EmailConfirmedAsync);
+                string controller = nameof(RegistrationController);
+                controller = controller.Remove(controller.Length - 10);
+                string confirmationTokenLink = Url.Action(action, controller, new
+                {
+                    username = user.UserName,
+                    token = confirmationToken
+                }, protocol: HttpContext.Request.Scheme);
+
+                MailAddress fromAddress = new MailAddress("votingnotification6@gmail.com", "Voting Online");
+                MailAddress toAddress = new MailAddress(user.Email, user.UserName);
+                const string fromPassword = "Team6Admin";
+                const string subject = "Welcome, Confirmation Email";
+                string body = $"Hello {user.UserName}.\nPlease confirm your email address by following this <a href=\"{confirmationTokenLink}\">link</a>.\nThank you.";
+
+                var smtp = new SmtpClient
+                {
+                    Host = "smtp.gmail.com",
+                    Port = 587,
+                    EnableSsl = true,
+                    DeliveryMethod = SmtpDeliveryMethod.Network,
+                    UseDefaultCredentials = false,
+                    Credentials = new NetworkCredential(fromAddress.Address, fromPassword)
+                };
+
+                var message = new MailMessage
+                {
+                    From = fromAddress,
+                    Subject = subject,
+                    Body = body,
+                    IsBodyHtml = true
+                };
+
+                message.To.Add(toAddress);
+                await smtp.SendMailAsync(message);
+            }
+        }
+
+        [HttpGet]
+        // this is not implemented yet
+        //[RequireHttps]
+        public async Task<IActionResult> VerifyEmail(string email)
+        {
+            if (_UserManager != null)
+            {
+                var user = await _UserManager.FindByEmailAsync(email);
+                
+                if(user == null)
+                {
+                    return Json($"Email: {email} is not valid for any user.");
+                }
+                else if (user.EmailConfirmed)
+                {
+                    return Json($"Email: {email} is already confirmed.");
+                }
+            }
+
+            return Json(true);
+        }
+
     }
 }

--- a/VotingApplication/Startup.cs
+++ b/VotingApplication/Startup.cs
@@ -36,7 +36,7 @@ namespace VotingApplication
                 // adds a provider that generates unique keys and hashes for things like
                 // forgot password links, phone number verification codes etc...
                 .AddDefaultTokenProviders();
-
+            
             // change password policy
             services.Configure<IdentityOptions>(options =>
             {
@@ -56,6 +56,7 @@ namespace VotingApplication
 
                 // User settings
                 options.User.RequireUniqueEmail = true;
+                options.SignIn.RequireConfirmedEmail = true;
             });
 
             // alter application cookie info

--- a/VotingApplication/ViewModels/ConfirmEmailViewModel.cs
+++ b/VotingApplication/ViewModels/ConfirmEmailViewModel.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace VotingApplication.ViewModels
+{
+    public class ConfirmEmailViewModel
+    {
+        [Required]
+        [EmailAddress]
+        [Remote(action: "VerifyEmail", controller: "Registration")]
+        [Display(Name = "Email")]
+        public string Email { get; set; }
+    }
+}

--- a/VotingApplication/ViewModels/ConfirmEmailViewModel.cs
+++ b/VotingApplication/ViewModels/ConfirmEmailViewModel.cs
@@ -9,6 +9,16 @@ namespace VotingApplication.ViewModels
 {
     public class ConfirmEmailViewModel
     {
+        public enum Status
+        {
+            Sent,
+            Request,
+            Error,
+        }
+
+        [HiddenInput]
+        public Status State { get; set; }
+
         [Required]
         [EmailAddress]
         [Remote(action: "VerifyEmail", controller: "Registration")]

--- a/VotingApplication/Views/Authentication/Login.cshtml
+++ b/VotingApplication/Views/Authentication/Login.cshtml
@@ -25,3 +25,4 @@
 </form>
 <a asp-area="" asp-controller="Registration" asp-action="Register" class="nav-link">New User?</a>
 <a asp-area="" asp-controller="User" asp-action="ForgotPassword" class="nav-link">Forgot Password?</a>
+<a asp-area="" asp-controller="Registration" asp-action="RequestEmailConfirmation" class="nav-link">Resend Email Confirmation?</a>

--- a/VotingApplication/Views/Registration/EmailConfirmationSent.cshtml
+++ b/VotingApplication/Views/Registration/EmailConfirmationSent.cshtml
@@ -1,0 +1,32 @@
+﻿@model ConfirmEmailViewModel
+<script>
+    $.validator.setDefaults({
+        onkeyup: false
+    })
+</script>
+
+<h1>Email Confirmation Sent</h1>
+@if (Model == null)
+{
+    <p>
+        Check your email for a confirmation letter, once your email is confirmed you will be able to login.
+    </p>
+}
+else
+{
+    <p>
+        Unable to confirm your email, try resending the confirmation email.
+    </p>
+    <div class="text-danger">
+        @Html.ValidationSummary()
+    </div>
+}
+<form asp-action="EmailConfirmationSentAsync" asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post" autocomplete="off">
+    <h4 class="form-signin-heading">Lost Email Confirmation.</h4>
+    <div class="form-group">
+        <label asp-for="Email"></label>
+        <input asp-for="Email" class="form-control" placeholder="Email" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Resend Confirmation Email</button>
+</form>

--- a/VotingApplication/Views/Registration/EmailConfirmationSent.cshtml
+++ b/VotingApplication/Views/Registration/EmailConfirmationSent.cshtml
@@ -5,24 +5,29 @@
     })
 </script>
 
-<h1>Email Confirmation Sent</h1>
-@if (Model == null)
+@if (Model.State == ConfirmEmailViewModel.Status.Sent)
 {
+    <h1>Email Confirmation Sent</h1>
     <p>
         Check your email for a confirmation letter, once your email is confirmed you will be able to login.
     </p>
 }
-else
+else if (Model.State == ConfirmEmailViewModel.Status.Error)
 {
+    <h1>Email Confirmation Error</h1>
     <p>
         Unable to confirm your email, try resending the confirmation email.
     </p>
-    <div class="text-danger">
-        @Html.ValidationSummary()
-    </div>
+}
+else if (Model.State == ConfirmEmailViewModel.Status.Request)
+{
+    <h1>Email Confirmation Request</h1>
+    <p>
+        If you have not received an email confirmation link or lost it, request one below.
+    </p>
 }
 <form asp-action="EmailConfirmationSentAsync" asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post" autocomplete="off">
-    <h4 class="form-signin-heading">Lost Email Confirmation.</h4>
+    <h4 class="form-signin-heading">Resend Email Confirmation.</h4>
     <div class="form-group">
         <label asp-for="Email"></label>
         <input asp-for="Email" class="form-control" placeholder="Email" />

--- a/VotingApplication/Views/Registration/EmailConfirmed.cshtml
+++ b/VotingApplication/Views/Registration/EmailConfirmed.cshtml
@@ -1,0 +1,5 @@
+﻿<h1>Email Confirmed</h1>
+<p>
+    Now that your email is confirmed, you can login.
+</p>
+<a asp-area="" asp-controller="Authentication" asp-action="Login" class="nav-link">Login</a>

--- a/VotingApplication/Views/Registration/Register.cshtml
+++ b/VotingApplication/Views/Registration/Register.cshtml
@@ -34,3 +34,4 @@
     <button type="submit" class="btn btn-primary">@ViewData["Submit"]</button>
 </form>
 <a asp-area="" asp-controller="Authentication" asp-action="Login" class="nav-link">Already have an account?</a>
+<a asp-area="" asp-controller="Registration" asp-action="RequestEmailConfirmation" class="nav-link">Resend Email Confirmation?</a>


### PR DESCRIPTION
Added error when user tries to login without confirming their email first. 

Removed return URL from register, the user should always be sent to the confirmation email sent page. 

Removed automatic login when a user registers, may put auto login when the user confirms their email. Is auto login after they click the email confirmation from their email a security risk? 

Added two pages, email confirmed and email confirmation sent. Email confirmation sent allows the user to resend the confirmation email. confirmation emails can only be requested for users who have to verify their email.

Allow users to resend email confirmation through login page and registration page.